### PR TITLE
add support for hashes

### DIFF
--- a/redeye/main.py
+++ b/redeye/main.py
@@ -18,6 +18,9 @@ def get_vals_for_key(conn, key):
     elif redis_type == 'zset':
         count = conn.zcard(key)
         vals = conn.zrange(key, 0, 2)
+    elif redis_type == 'hash':
+        count = conn.hlen(key)
+        vals = 'hset'
     else:
         print "Got unknown type {}".format(redis_type)
     return redis_type, count, vals


### PR DESCRIPTION
@spulec `redeye` was giving me the following:

`Traceback (most recent call last):
  File "/Users/shaunviguerie/.virtualenvs/jd/bin/redeye", line 11, in <module>
    sys.exit(main())
  File "/Users/shaunviguerie/.virtualenvs/jd/lib/python2.7/site-packages/redeye/main.py", line 44, in main
    check_keys(conn)
  File "/Users/shaunviguerie/.virtualenvs/jd/lib/python2.7/site-packages/redeye/main.py", line 30, in check_keys
    key_type, count, vals = get_vals_for_key(conn, key)
  File "/Users/shaunviguerie/.virtualenvs/jd/lib/python2.7/site-packages/redeye/main.py", line 23, in get_vals_for_key
    return redis_type, count, vals
UnboundLocalError: local variable 'count' referenced before assignment`

Whenever an `HSET` was called in code I was monitoring with redeye.  This PR stops this from crashing by handling the hash case-- unfortunately we don't seem to have the convenience of a `ZRANGE` to show a few of the values in the redis hash, so for now I'm just exposing the # of vals in the set.

Maybe there is something else we could show? http://redis.io/commands#hash 
